### PR TITLE
Intruduced basic CMake configuration

### DIFF
--- a/BoostConfigConfig.cmake
+++ b/BoostConfigConfig.cmake
@@ -1,0 +1,6 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+include(CMakeFindDependencyMacro)
+include("${CMAKE_CURRENT_LIST_DIR}/BoostConfigTargets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+project(BoostConfig VERSION 1.66 LANGUAGES CXX)
+
+add_library(config INTERFACE)
+
+target_include_directories(config INTERFACE 
+    $<BUILD_INTERFACE:${BoostConfig_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${BoostConfig_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    )
+
+target_link_libraries(config INTERFACE)
+
+install(EXPORT config-targets
+    FILE BoostConfigTargets.cmake
+    NAMESPACE Boost::
+    DESTINATION lib/cmake/boost
+    )
+
+install(TARGETS config EXPORT config-targets
+    INCLUDES DESTINATION include
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("BoostConfigConfigVersion.cmake"
+    VERSION ${BoostConfig_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+install(
+    FILES
+        "BoostConfigConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/BoostConfigConfigVersion.cmake"
+    DESTINATION
+        lib/cmake/boost
+    )
+install(DIRECTORY include/ DESTINATION include)
+
+add_library(Boost::config ALIAS config)


### PR DESCRIPTION
Expresses Boost::config as an `INTERFACE` library in CMake.
- use via `add_subdirectory` 
- use via `find_package(BoostConfig 1.66)` if previously installed. This is achieved via the following install:
```
$INSTALL_PREFIX
├── include
│   └── boost
│       ├── config
│       │   ├── abi
│       │   │   ├── borland_prefix.hpp
│       │   │   ├── borland_suffix.hpp
│       │   │   ├── msvc_prefix.hpp
│       │   │   └── msvc_suffix.hpp
│       │   ├── abi_prefix.hpp
│       │   ├── abi_suffix.hpp
│       │   ├── auto_link.hpp
│       │   ├── compiler
│       │   │   ├── borland.hpp
│       │   │   ├── clang.hpp
│       │   │   ├── codegear.hpp
│       │   │   ├── comeau.hpp
│       │   │   ├── common_edg.hpp
│       │   │   ├── compaq_cxx.hpp
│       │   │   ├── cray.hpp
│       │   │   ├── diab.hpp
│       │   │   ├── digitalmars.hpp
│       │   │   ├── gcc.hpp
│       │   │   ├── gcc_xml.hpp
│       │   │   ├── greenhills.hpp
│       │   │   ├── hp_acc.hpp
│       │   │   ├── intel.hpp
│       │   │   ├── kai.hpp
│       │   │   ├── metrowerks.hpp
│       │   │   ├── mpw.hpp
│       │   │   ├── nvcc.hpp
│       │   │   ├── pathscale.hpp
│       │   │   ├── pgi.hpp
│       │   │   ├── sgi_mipspro.hpp
│       │   │   ├── sunpro_cc.hpp
│       │   │   ├── vacpp.hpp
│       │   │   ├── visualc.hpp
│       │   │   ├── xlcpp.hpp
│       │   │   └── xlcpp_zos.hpp
│       │   ├── detail
│       │   │   ├── posix_features.hpp
│       │   │   ├── select_compiler_config.hpp
│       │   │   ├── select_platform_config.hpp
│       │   │   ├── select_stdlib_config.hpp
│       │   │   └── suffix.hpp
│       │   ├── no_tr1
│       │   │   ├── cmath.hpp
│       │   │   ├── complex.hpp
│       │   │   ├── functional.hpp
│       │   │   ├── memory.hpp
│       │   │   └── utility.hpp
│       │   ├── platform
│       │   │   ├── aix.hpp
│       │   │   ├── amigaos.hpp
│       │   │   ├── beos.hpp
│       │   │   ├── bsd.hpp
│       │   │   ├── cloudabi.hpp
│       │   │   ├── cray.hpp
│       │   │   ├── cygwin.hpp
│       │   │   ├── haiku.hpp
│       │   │   ├── hpux.hpp
│       │   │   ├── irix.hpp
│       │   │   ├── linux.hpp
│       │   │   ├── macos.hpp
│       │   │   ├── qnxnto.hpp
│       │   │   ├── solaris.hpp
│       │   │   ├── symbian.hpp
│       │   │   ├── vms.hpp
│       │   │   ├── vxworks.hpp
│       │   │   ├── win32.hpp
│       │   │   └── zos.hpp
│       │   ├── requires_threads.hpp
│       │   ├── stdlib
│       │   │   ├── dinkumware.hpp
│       │   │   ├── libcomo.hpp
│       │   │   ├── libcpp.hpp
│       │   │   ├── libstdcpp3.hpp
│       │   │   ├── modena.hpp
│       │   │   ├── msl.hpp
│       │   │   ├── roguewave.hpp
│       │   │   ├── sgi.hpp
│       │   │   ├── stlport.hpp
│       │   │   ├── vacpp.hpp
│       │   │   └── xlcpp_zos.hpp
│       │   ├── user.hpp
│       │   ├── warning_disable.hpp
│       │   └── workaround.hpp
│       ├── config.hpp
│       ├── cstdint.hpp
│       ├── cxx11_char_types.hpp
│       ├── detail
│       │   └── workaround.hpp
│       ├── limits.hpp
│       └── version.hpp
└── lib
    └── cmake
        └── boost
            ├── BoostConfigConfig.cmake
            ├── BoostConfigConfigVersion.cmake
            └── BoostConfigTargets.cmake

13 directories, 86 files
```
- tests are __not__ included in the build